### PR TITLE
FIX/ updated base-image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as builder
+FROM golang:1.17 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
# What?

When building the image this error came up:

```
undefined: unsafe.Slice
```

# Solution

The quick solution was to update the base-image